### PR TITLE
Fix issue 1: Remove folders in results, grab top results from refinedResults

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MacOS Spotlight-like Chrome extension for bookmarks
     * Use `Tab` (and `Shift + Tab`) to navigate selections, or hit `Enter` to go to the top result
 
 ## Development/Testing
-[https://github.com/Ecalzo/Skater/releases](download latest release)
+[download latest release](https://github.com/Ecalzo/Skater/releases)
 
 1. Unzip
 2. Go to chrome://extensions/ in browser

--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ MacOS Spotlight-like Chrome extension for bookmarks
 * `Ctrl + Shift + L` to open the prompt
 * Search your bookmarks!
     * Use `Tab` (and `Shift + Tab`) to navigate selections, or hit `Enter` to go to the top result
+
+## Development/Testing
+[https://github.com/Ecalzo/Skater/releases](download latest release)
+
+1. Unzip
+2. Go to chrome://extensions/ in browser
+3. Enable Developer Mode
+4. Click Load Unpacked in top left and target the unzipped folder
+5. use `Ctrl+Shift+L` or `Cmd+Shift+L` and start searching your bookmarks super fast

--- a/popup.js
+++ b/popup.js
@@ -56,7 +56,6 @@ function updateSearchText(results) {
   const resultView = getSearchResultsElement();
   // wipes the unordered list
   resultView.innerHTML = '';
-  debugger
   results.forEach(result => {
     resultView.appendChild(
       createListItem(result)

--- a/popup.js
+++ b/popup.js
@@ -32,7 +32,7 @@ function refineResults(searchResults, query) {
     const queryLen = query.length;
     const queryLower = query.toLowerCase();
     const bookmarkTitle = result.title.substring(0, queryLen).toLowerCase();
-    return bookmarkTitle.includes(queryLower);
+    return bookmarkTitle.includes(queryLower) & result.hasOwnProperty('url');
   });
 }
 
@@ -56,6 +56,7 @@ function updateSearchText(results) {
   const resultView = getSearchResultsElement();
   // wipes the unordered list
   resultView.innerHTML = '';
+  debugger
   results.forEach(result => {
     resultView.appendChild(
       createListItem(result)

--- a/popup.js
+++ b/popup.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function() {
     updateLinkEventListeners();
     if (event.key === "Enter") {
       // go to first event in the list
-      const top_result = searchResults[0];
+      const top_result = refinedResults[0];
       window.open(top_result.url)
     }
   });


### PR DESCRIPTION
fixes #1  
* Removes folders from results by checking if a result object has a `'url'` property
* Fixes bug where top result was grabbed from unfiltered results list