### PR TITLE
Refactor: Use a chrome command to launch Skater (configurable hotkey)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ MacOS Spotlight-like Chrome extension for bookmarks
 2. Go to chrome://extensions/ in browser
 3. Enable Developer Mode
 4. Click Load Unpacked in top left and target the unzipped folder
-5. use `Ctrl + K` or `Cmd + K` and start searching your bookmarks super fast
+5. use `Ctrl + Shift + Space` or `Cmd + Shift + Space` and start searching your bookmarks super fast

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ MacOS Spotlight-like Chrome extension for bookmarks
 
 ## Usage
 * Install Extension from the [chrome web store](https://chrome.google.com/webstore/detail/skater/goeeolknplhjegbfefjgeekeobpehekf)
-* `Ctrl + /` or `Cmd + /` to open the prompt
+* `Ctrl + K` or `Cmd + K` to open the prompt
+    * [You can also configure this hotkey](https://pureinfotech.com/add-keyboard-shortcuts-extensions-chrome/)
 * Search your bookmarks!
     * Use `↑` and `↓` to navigate results
     * Skate to your selected website with `Enter`
@@ -17,4 +18,4 @@ MacOS Spotlight-like Chrome extension for bookmarks
 2. Go to chrome://extensions/ in browser
 3. Enable Developer Mode
 4. Click Load Unpacked in top left and target the unzipped folder
-5. use `Ctrl + /` or `Cmd + /` and start searching your bookmarks super fast
+5. use `Ctrl + K` or `Cmd + K` and start searching your bookmarks super fast

--- a/background.js
+++ b/background.js
@@ -31,6 +31,7 @@ chrome.runtime.onMessage.addListener(
 );
 
 chrome.commands.onCommand.addListener(function(command) {
+  // This is waiting for the 'launch' command to trigger
   sendContentScriptMessage({command: command});
 });
 

--- a/background.js
+++ b/background.js
@@ -19,7 +19,7 @@ chrome.runtime.onMessage.addListener(
         } else { // else, open a new tab
           chrome.tabs.create({url: request.url, active: true});
         }
-      });
+        });
     } else {
       sendResponse([]);
     }
@@ -31,6 +31,7 @@ chrome.runtime.onMessage.addListener(
 chrome.commands.onCommand.addListener(function(command) {
   // This is waiting for the 'launch' command to trigger
   sendContentScriptMessage({command: command});
+  return true
 });
 
 function sendContentScriptMessage(query_object) {

--- a/background.js
+++ b/background.js
@@ -37,9 +37,7 @@ chrome.commands.onCommand.addListener(function(command) {
 
 function sendContentScriptMessage(query_object) {
   chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-    chrome.tabs.sendMessage(tabs[0].id, query_object, function(response) {
-      console.log(response);
-    });
+    chrome.tabs.sendMessage(tabs[0].id, query_object, () => true);
     return true
   });
 }

--- a/background.js
+++ b/background.js
@@ -31,10 +31,10 @@ chrome.runtime.onMessage.addListener(
 );
 
 chrome.commands.onCommand.addListener(function(command) {
-  sendMessage({command: command});
+  sendContentScriptMessage({command: command});
 });
 
-function sendMessage(query_object) {
+function sendContentScriptMessage(query_object) {
   chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
     chrome.tabs.sendMessage(tabs[0].id, query_object, function(response) {
       console.log(response);

--- a/background.js
+++ b/background.js
@@ -16,10 +16,8 @@ chrome.runtime.onMessage.addListener(
         chrome.tabs.query({url: queryUrl}, e => {
         if (e.length) { // if the tab exists, go to it
           chrome.tabs.update(e[0].id, {active: true});
-          // sendResponse(e);
         } else { // else, open a new tab
           chrome.tabs.create({url: request.url, active: true});
-          // sendResponse([]);
         }
       });
     } else {

--- a/background.js
+++ b/background.js
@@ -14,11 +14,11 @@ chrome.runtime.onMessage.addListener(
           queryUrl = request.url
         }
         chrome.tabs.query({url: queryUrl}, e => {
-        if (e.length) { // if the tab exists, go to it
-          chrome.tabs.update(e[0].id, {active: true});
-        } else { // else, open a new tab
-          chrome.tabs.create({url: request.url, active: true});
-        }
+          if (e.length) { // if the tab exists, go to it
+            chrome.tabs.update(e[0].id, {active: true});
+          } else { // else, open a new tab
+            chrome.tabs.create({url: request.url, active: true});
+          }
         });
     } else {
       sendResponse([]);

--- a/background.js
+++ b/background.js
@@ -30,4 +30,15 @@ chrome.runtime.onMessage.addListener(
   }
 );
 
+chrome.commands.onCommand.addListener(function(command) {
+  sendMessage({command: command});
+});
 
+function sendMessage(query_object) {
+  chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+    chrome.tabs.sendMessage(tabs[0].id, query_object, function(response) {
+      console.log(response);
+    });
+    return true
+  });
+}

--- a/manifest.json
+++ b/manifest.json
@@ -32,8 +32,8 @@
     "commands": {
         "launch": {
           "suggested_key": {
-            "default": "Ctrl+K",
-            "mac": "Command+K"
+            "default": "Ctrl+Shift+Space",
+            "mac": "Command+Shift+Space"
           },
           "description": "launch Skater"
         }

--- a/manifest.json
+++ b/manifest.json
@@ -32,8 +32,8 @@
     "commands": {
         "launch": {
           "suggested_key": {
-            "default": "Ctrl+Shift+Y",
-            "mac": "Command+Shift+Y"
+            "default": "Ctrl+K",
+            "mac": "Command+K"
           },
           "description": "launch Skater"
         }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
     "name": "Skater",
     "description": "Spotlight-like extension for Chrome bookmarks",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "icons": {
         "16": "icon16.png",
         "24": "icon24.png",

--- a/manifest.json
+++ b/manifest.json
@@ -28,5 +28,14 @@
     "permissions": [
         "bookmarks",
         "tabs"
-    ]
+    ],
+    "commands": {
+        "launch": {
+          "suggested_key": {
+            "default": "Ctrl+Shift+Y",
+            "mac": "Command+Shift+Y"
+          },
+          "description": "launch Skater"
+        }
+    }
 }

--- a/overlay.js
+++ b/overlay.js
@@ -1,5 +1,5 @@
 chrome.runtime.onMessage.addListener(
-    async function(_, _, _) {
+    async function(_, _, sendResponse) {
         // check if our overlay exists already
         if (!getOverlayDiv()) {
             createOverlay();
@@ -9,6 +9,8 @@ chrome.runtime.onMessage.addListener(
         } else {
             focusInput();
         }
+        sendResponse([]);
+        return true
     }
 );
 

--- a/overlay.js
+++ b/overlay.js
@@ -1,5 +1,5 @@
 chrome.runtime.onMessage.addListener(
-    async function(request, sender, sendResponse) {
+    async function(_, _, _) {
         if (!document.querySelector('#skater-overlay')) {
             createOverlay();
             setUpInputEventListener();

--- a/overlay.js
+++ b/overlay.js
@@ -82,7 +82,7 @@ async function goTo(url) {
 }
 
 function isValidInputEvent(key) {
-    const isAlphabetical = (key >= "a" && key <= "z") || (key >= "A" && key <= "Z") && key.length == 1;
+    const isAlphabetical = (key >= "a" && key <= "z") || (key >= "A" && key <= "Z") && key.length === 1;
     const isNumeric = (key >= "0" && key <= "9");
     const isBackspace = (key === "Backspace");
     const isEnter = (key === "Enter");

--- a/overlay.js
+++ b/overlay.js
@@ -9,8 +9,8 @@ chrome.runtime.onMessage.addListener(
         } else {
             focusInput();
         }
-        return true
-});
+    }
+);
 
 async function setUpOverlayEventListener() {
     const overlayDiv = getOverlayDiv();

--- a/overlay.js
+++ b/overlay.js
@@ -5,15 +5,16 @@ chrome.runtime.onMessage.addListener(
             createOverlay();
             setUpInputEventListener();
             setTimeout(() => focusInput(), 100);
-            await setUpDocumentEventListener();
+            await setUpOverlayEventListener();
         } else {
             focusInput();
         }
         return true
 });
 
-async function setUpDocumentEventListener() {
-    document.addEventListener('keydown', async function(documentEvent) {
+async function setUpOverlayEventListener() {
+    const overlayDiv = getOverlayDiv();
+    overlayDiv.addEventListener('keydown', async function(documentEvent) {
         if (getSearchInputElement()) {
             focusInput();
             const focusedElement = getFocusedListElement();

--- a/overlay.js
+++ b/overlay.js
@@ -4,12 +4,12 @@ chrome.runtime.onMessage.addListener(
             createOverlay();
             setUpInputEventListener();
             setTimeout(() => focusInput(), 100);
-            await launchOverlay();
+            await setUpDocumentEventListener();
         }
         return true
 });
 
-async function launchOverlay() {
+async function setUpDocumentEventListener() {
     document.addEventListener('keydown', async function(documentEvent) {
         if (getSearchInputElement()) {
             focusInput();

--- a/overlay.js
+++ b/overlay.js
@@ -82,7 +82,7 @@ async function goTo(url) {
 }
 
 function isValidInputEvent(key) {
-    const isAlphabetical = (key >= "a" && key <= "z") || (key >= "A" && key <= "Z");
+    const isAlphabetical = (key >= "a" && key <= "z");
     const isNumeric = (key >= "0" && key <= "9");
     const isBackspace = (key === "Backspace");
     const isEnter = (key === "Enter");

--- a/overlay.js
+++ b/overlay.js
@@ -82,12 +82,13 @@ async function goTo(url) {
 }
 
 function isValidInputEvent(key) {
-    const isAlphabetical = (key >= "a" && key <= "z");
+    const isAlphabetical = (key >= "a" && key <= "z") || (key >= "A" && key <= "Z") && key.length == 1;
     const isNumeric = (key >= "0" && key <= "9");
     const isBackspace = (key === "Backspace");
     const isEnter = (key === "Enter");
     const isShift = (key === "Shift");
-    return isAlphabetical || isNumeric || isBackspace || isEnter || isShift
+    const isArrowKey = (['ArrowUp', 'Up', 'ArrowDown', 'Down', 'ArrowLeft', 'Left', 'ArrowRight', 'Right'].includes(key))
+    return (isAlphabetical || isNumeric || isBackspace || isEnter || isShift) && !isArrowKey
 }
 
 function stripIndexFromClass(element) {

--- a/overlay.js
+++ b/overlay.js
@@ -1,10 +1,13 @@
 chrome.runtime.onMessage.addListener(
     async function(_, _, _) {
+        // check if our overlay exists already
         if (!document.querySelector('#skater-overlay')) {
             createOverlay();
             setUpInputEventListener();
             setTimeout(() => focusInput(), 100);
             await setUpDocumentEventListener();
+        } else {
+            focusInput();
         }
         return true
 });

--- a/overlay.js
+++ b/overlay.js
@@ -82,11 +82,12 @@ async function goTo(url) {
 }
 
 function isValidInputEvent(key) {
-    const isAlphabetical = (key >= "a" && key <= "z");
+    const isAlphabetical = (key >= "a" && key <= "z") || (key >= "A" && key <= "Z");
     const isNumeric = (key >= "0" && key <= "9");
     const isBackspace = (key === "Backspace");
     const isEnter = (key === "Enter");
-    return isAlphabetical || isNumeric || isBackspace || isEnter
+    const isShift = (key === "Shift");
+    return isAlphabetical || isNumeric || isBackspace || isEnter || isShift
 }
 
 function stripIndexFromClass(element) {

--- a/overlay.js
+++ b/overlay.js
@@ -1,52 +1,55 @@
-document.addEventListener('keydown', async function(documentEvent) {
-    const isUnix = navigator.platform.toUpperCase().indexOf('MAC') >= 0 || navigator.platform.toUpperCase().indexOf('LINUX') >= 0;
-    if (
-        ((documentEvent.ctrlKey && !isUnix)
-        || (documentEvent.metaKey && isUnix))
-        && documentEvent.key === '/'
-        && !document.querySelector('#skater-overlay')
-    ) {
-        createOverlay();
-        setUpInputEventListener();
-        setTimeout(() => focusInput(), 100);
-    } else if (getSearchInputElement()) {
-        focusInput();
-        const focusedElement = getFocusedListElement();
-        switch(documentEvent.key) {
-            case "Up":
-            case "ArrowUp":
-                if (focusedElement.getAttribute('class') === 'skater-link skater-result-0 skater-focused') {
-                    focusInput();
-                } else if (focusedElement.isSameNode(getSearchInputElement())) {
-                    // do nothing
-                } else {
-                    // move to previous result
-                    moveUpOneResult();
-                    documentEvent.preventDefault();
-                }
-                return true
-            case "Down":
-            case "ArrowDown":
-                // move to next search result
-                moveDownOneResult();
-                return true
-            case "Enter":
-                // go to first inputEvent in the list
-                const selectedResult = getFocusedListElement();
-                if (documentEvent.ctrlKey){
-                    // open in same window
-                } else {
-                    destroyOverlay();                   
-                    await goTo(selectedResult.href);
-                }
-            case "Escape":
-                destroyOverlay();
+chrome.runtime.onMessage.addListener(
+    async function(request, sender, sendResponse) {
+        if (!document.querySelector('#skater-overlay')) {
+            createOverlay();
+            setUpInputEventListener();
+            setTimeout(() => focusInput(), 100);
+            await launchOverlay();
         }
-    }
-    if (documentEvent.key === "Escape") {
-    }
-    return true
+        return true
 });
+
+async function launchOverlay() {
+    document.addEventListener('keydown', async function(documentEvent) {
+        if (getSearchInputElement()) {
+            focusInput();
+            const focusedElement = getFocusedListElement();
+            switch(documentEvent.key) {
+                case "Up":
+                case "ArrowUp":
+                    if (focusedElement.getAttribute('class') === 'skater-link skater-result-0 skater-focused') {
+                        focusInput();
+                    } else if (focusedElement.isSameNode(getSearchInputElement())) {
+                        // do nothing
+                    } else {
+                        // move to previous result
+                        moveUpOneResult();
+                        documentEvent.preventDefault();
+                    }
+                    return true
+                case "Down":
+                case "ArrowDown":
+                    // move to next search result
+                    moveDownOneResult();
+                    return true
+                case "Enter":
+                    // go to first inputEvent in the list
+                    const selectedResult = getFocusedListElement();
+                    if (documentEvent.ctrlKey){
+                        // open in same window
+                    } else {
+                        destroyOverlay();                   
+                        await goTo(selectedResult.href);
+                    }
+                case "Escape":
+                    destroyOverlay();
+            }
+        }
+        if (documentEvent.key === "Escape") {
+        }
+        return true
+    });
+}
 
 function setUpInputEventListener() {
     const searchInput = getSearchInputElement();

--- a/overlay.js
+++ b/overlay.js
@@ -196,7 +196,9 @@ function createOverlay() {
 
 function destroyOverlay() {
     const overlayDiv = getOverlayDiv();
-    overlayDiv.parentNode.removeChild(overlayDiv);
+    if (overlayDiv) {
+        overlayDiv.parentNode.removeChild(overlayDiv);
+    }
 }
 
 function createOverlayDiv () {

--- a/overlay.js
+++ b/overlay.js
@@ -49,8 +49,6 @@ async function setUpOverlayEventListener() {
                     destroyOverlay();
             }
         }
-        if (documentEvent.key === "Escape") {
-        }
         return true
     });
 }

--- a/overlay.js
+++ b/overlay.js
@@ -1,7 +1,7 @@
 chrome.runtime.onMessage.addListener(
     async function(_, _, _) {
         // check if our overlay exists already
-        if (!document.querySelector('#skater-overlay')) {
+        if (!getOverlayDiv()) {
             createOverlay();
             setUpInputEventListener();
             setTimeout(() => focusInput(), 100);

--- a/popup.html
+++ b/popup.html
@@ -9,6 +9,6 @@
         <img id="skater-icon" src="icon128.png"> </br>
         <a href="https://github.com/Ecalzo/Skater" class="fa fa-github"></a>
         <a href="https://chrome.google.com/webstore/detail/skater/goeeolknplhjegbfefjgeekeobpehekf" class="fa fa-google"></a>
-        <p>Use Ctrl + / or Cmd + / to open search!</p>
+        <h4>Use Ctrl + K or Cmd + K to open search!</h4>
     </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -7,8 +7,8 @@
     </head>
     <body>
         <img id="skater-icon" src="icon128.png"> </br>
-        <a href="https://github.com/Ecalzo/Skater" class="fa fa-github"></a>
-        <a href="https://chrome.google.com/webstore/detail/skater/goeeolknplhjegbfefjgeekeobpehekf" class="fa fa-google"></a>
+        <a href="https://github.com/Ecalzo/Skater" class="fa fa-github" target="_blank"></a>
+        <a href="https://chrome.google.com/webstore/detail/skater/goeeolknplhjegbfefjgeekeobpehekf" class="fa fa-google" target="_blank"></a>
         <h4>Use Ctrl + K or Cmd + K to open search!</h4>
     </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -9,6 +9,6 @@
         <img id="skater-icon" src="icon128.png"> </br>
         <a href="https://github.com/Ecalzo/Skater" class="fa fa-github" target="_blank"></a>
         <a href="https://chrome.google.com/webstore/detail/skater/goeeolknplhjegbfefjgeekeobpehekf" class="fa fa-google" target="_blank"></a>
-        <h4>Use Ctrl + K or Cmd + K to open search!</h4>
+        <h4>Use Ctrl + Shift + Space or Cmd + Shift + Space to open search!</h4>
     </body>
 </html>


### PR DESCRIPTION
The main goal of this PR is to launch Skater with a chrome `command`. This allows the user to reconfigure the hotkey at will, significantly improving the user experience.

As for the code, it looks like there is more changing here than actually is, because the event listener handling `keydown` events needed to be moved into a function, `setUpOverlayEventListener`.

### Main changes:

`background.js`:
* Add `chrome.commands.onCommand` event listener, looking for the hotkey input
* Add `sendContentScriptMessage` to allow the background script to send a message to the content script

`overlay.js`
* Rescope `keydown` event listener to `#skater-overlay` (prevents setting up redundant listeners)
* Create `setUpOverlayEventListener` and place the keydown event listener in this function
* Handle initial launch of skater in `chrome.runtime.onMessage` listener 
* Add some error handling to `destroyOverlay`

Otherwise, there are small formatting and misc. changes.

Fixes #9 